### PR TITLE
Update the Opalrb's URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/youchan/menilite.svg?branch=master)](https://travis-ci.org/youchan/menilite)
 
 An isomorphic web programming framework in Ruby.  
-Ruby codes also run on the client side by using [Opalrb](http://opalrb.org).
+Ruby codes also run on the client side by using [Opalrb](http://opalrb.com).
 
 ## Installation
 


### PR DESCRIPTION
Hi, there. Apparently, the website has moved to opalrb.com
https://github.com/opal/opal/issues/1747